### PR TITLE
readdirp throwing an error event should reject the promise

### DIFF
--- a/src/packages/index.js
+++ b/src/packages/index.js
@@ -22,18 +22,14 @@ function getPackages(paths, opts) {
   opts = opts || {};
   return reduce(function (result, path) {
     return new Promise(function (resolve, reject) {
-      var error;
       readdirp({root: path, depth: opts.recursive ? null : 1, fileFilter: 'package.json'})
         .on('data', function (d) {
           result.push(d.fullPath);
         })
         .on('error', function (err) {
-          error = err;
+	  reject(err);
         })
         .on('end', function () {
-          if (error && error.code !== 'ENOENT') {
-            return reject(error);
-          }
           resolve(result);
         });
     });


### PR DESCRIPTION
The docs for [readdirp](https://github.com/thlorenz/readdirp) says that when an `error` event occurs the stream is terminated immediately. I believe this means that if any error occurs the `end` event never gets fired as it expects `error` to do all the work for it. You might have meant `close` instead possibly?

In the code handling this you cache the error object then decide what to do in the `end` event which will never fire if `error` fires first.

I came across this when running the module on a Windows machine where the users node_modules directory does not exist - it should throw a ENOENT but instead just silently crashes.

The above is true on a Win 8/64 machine. Not sure if the behaviour is any different on another OS.
